### PR TITLE
add rule for local coverage reports

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,19 +23,7 @@ build:verbose-clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=//tools:ver
 build:clang-tidy --config=clang-tidy-base
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_toolchain//:clang-tidy
 
-coverage --combined_report=lcov
-coverage --strategy=CoverageReport=local
-
-# At least some of this is needed for the coverage tool to work.
-coverage --experimental_split_coverage_postprocessing
-coverage --experimental_fetch_all_coverage_outputs
-coverage --remote_download_outputs=all
-coverage --experimental_remote_download_regex=.*/((testlogs/.*/_coverage/.*)|coverage.dat$|_coverage/_coverage_report.dat$)
-
-# Not sure why it doesn't work with clang. Should be possible.
+# Clang will fail for tests that replace malloc and has worse coverage results than GCC
 coverage --extra_toolchains=//toolchain:gcc
-
-# Needed because our tests are in a different package than the code they test.
-coverage --instrumentation_filter='//...'
 
 try-import %workspace%/user.bazelrc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,8 +62,8 @@ jobs:
     - run: |
         bazel \
           --bazelrc=.github/workflows/ci.bazelrc \
-          coverage \
-          //...
+          run \
+          //tools:lcov_list
 
     - uses: codecov/codecov-action@v3
       with:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -140,3 +140,13 @@ bazel_skylib_workspace()
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()
+
+http_archive(
+    name = "lcov",
+    build_file_content = """
+exports_files(glob(["**/*"]))
+""",
+    sha256 = "987031ad5528c8a746d4b52b380bc1bffe412de1f2b9c2ba5224995668e3240b",
+    strip_prefix = "lcov-1.16",
+    url = "https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz",
+)

--- a/rules/lcov.bzl
+++ b/rules/lcov.bzl
@@ -1,0 +1,99 @@
+"""
+Rule for generating a coverage report
+"""
+
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@local_config_info//:defs.bzl", "BAZEL_BIN")
+
+def lcov(
+        name,
+        instrumented_targets = [],
+        test_targets = [],
+        coverage_opts = [
+            "--combined_report=lcov",
+            "--experimental_generate_llvm_lcov",
+            "--test_output=errors",
+            # https://github.com/bazelbuild/bazel/issues/13919
+            "--test_env=COVERAGE_GCOV_OPTIONS=-b",
+        ],
+        lcov_opts = []):
+    """
+    Generate an lcov reports from the output of Bazel's coverage command.
+
+    Args:
+      name: string
+        Name for `lcov` rule.
+      instrumented_targets: string_list
+        List of targets for which to determine coverage.
+      test_targets: string_list
+        List of targets used to determine coverage.
+      coverage_opts: string_list
+        Options passed to Bazel's coverage command.
+      lcov_opts: string_list
+        Options passed to lcov to generate a report.
+
+    instrumented_targets and test_targets are specified as strings which are
+    passed to the underlying coverage command, and may include wildcards.
+
+    Example:
+
+      lcov(
+        name = "lcov_list",
+        instrumented_targets = ["//:skytest"],
+        test_targets = ["//test/..."],
+        lcov_opts = ["--list", "--rc", "lcov_branch_coverage=1"],
+      )
+
+      bazel run :lcov_list
+    """
+    instrumented = [
+        "--instrumentation_filter={}".format(target)
+        for target in instrumented_targets
+    ]
+
+    coverage_command = " ".join(
+        ["{bazel} coverage {bazel_common_opts}"] +
+        coverage_opts + instrumented + test_targets,
+    )
+
+    lcov_command = " ".join(["\"${{lcov}}\""] + lcov_opts)
+
+    content = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        "lcov=\"$(pwd)/${{1}}\"",
+        "",
+        "unset TEST_TMPDIR",
+        "cd $BUILD_WORKSPACE_DIRECTORY",
+        "output_path=\"$({bazel} info {bazel_common_opts} output_path)\"",
+        "coverage_report=\"${{output_path}}/_coverage/_coverage_report.dat\"",
+        "",
+        coverage_command + " || true",
+        "",
+        lcov_command + " \"${{coverage_report}}\"",
+    ]
+
+    content = [
+        line.format(
+            bazel = BAZEL_BIN,
+            bazel_common_opts = "--color=yes --curses=yes",
+        )
+        for line in content
+    ]
+
+    write_file(
+        name = "gen_" + name,
+        out = name + ".sh",
+        content = content,
+        is_executable = True,
+        tags = ["manual"],
+        visibility = ["//visibility:private"],
+    )
+
+    native.sh_binary(
+        name = name,
+        srcs = [name + ".sh"],
+        data = ["@lcov//:bin/lcov"],
+        args = ["$(rootpath @lcov//:bin/lcov)"],
+    )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -4,6 +4,7 @@ load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//rules:incompatible.bzl", "incompatible_with_sanitizers")
+load("//rules:lcov.bzl", "lcov")
 
 config_setting_group = selects.config_setting_group
 
@@ -107,4 +108,15 @@ incompatible_with_sanitizers(
     sanitizers = ["ubsan"],
     visibility = ["//test:__pkg__"],
     deps = ["//tools:maybe_incompatible_clang"],
+)
+
+lcov(
+    name = "lcov_list",
+    instrumented_targets = ["//:skytest"],
+    lcov_opts = [
+        "--list",
+        "--rc",
+        "lcov_branch_coverage=1",
+    ],
+    test_targets = ["//test/..."],
 )


### PR DESCRIPTION
Add lcov 1.16 as an external dependency and define a rule to generate a
coverage report using lcov.

Enable branch coverage with GCC and move most coverage options out of
.bazelrc and to target `//tools:lcov_list`.

Update CI to use coverage data produced by `//tools:lcov_list`.

Change-Id: I37d33c025105fc85371605e0167d63d26becd74f