### PR TITLE
remove exception branches from coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,4 @@ build:verbose-clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=//tools:ver
 build:clang-tidy --config=clang-tidy-base
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_toolchain//:clang-tidy
 
-# Clang will fail for tests that replace malloc and has worse coverage results than GCC
-coverage --extra_toolchains=//toolchain:gcc
-
 try-import %workspace%/user.bazelrc

--- a/rules/lcov.bzl
+++ b/rules/lcov.bzl
@@ -13,8 +13,6 @@ def lcov(
             "--combined_report=lcov",
             "--experimental_generate_llvm_lcov",
             "--test_output=errors",
-            # https://github.com/bazelbuild/bazel/issues/13919
-            "--test_env=COVERAGE_GCOV_OPTIONS=-b",
         ],
         lcov_tool = "lcov",
         lcov_opts = []):

--- a/test/expect_message_test.cpp
+++ b/test/expect_message_test.cpp
@@ -1,5 +1,7 @@
 #include "skytest/skytest.hpp"
 
+#include <exception>
+
 auto main() -> int
 {
   using namespace ::skytest::literals;
@@ -18,8 +20,6 @@ auto main() -> int
   };
 
   "not invoked on success"_test = [] {
-    return expect(true, [](auto&) {
-      throw std::runtime_error{"should not be invoked"};
-    });
+    return expect(true, [](auto&) { std::terminate(); });
   };
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -110,27 +110,47 @@ incompatible_with_sanitizers(
     deps = ["//tools:maybe_incompatible_clang"],
 )
 
+lcov_attrs = {
+    "instrumented_targets": ["//:skytest"],
+    "test_targets": ["//test/..."],
+    "coverage_opts": [
+        "--combined_report=lcov",
+        "--experimental_generate_llvm_lcov",
+        "--test_output=errors",
+        "--extra_toolchains=//toolchain:gcc",
+        # https://github.com/bazelbuild/bazel/issues/13919
+        # https://github.com/bazelbuild/bazel/blob/master/tools/test/collect_cc_coverage.sh
+        "--test_env=COVERAGE_GCOV_OPTIONS=-b",
+        # https://gcovr.com/en/stable/faq.html#why-does-c-code-have-so-many-uncovered-branches
+        # https://stackoverflow.com/questions/42003783/lcov-gcov-branch-coverage-with-c-producing-branches-all-over-the-place
+        "--cxxopt=-fno-exceptions",
+    ],
+}
+
 lcov(
     name = "lcov_list",
-    instrumented_targets = ["//:skytest"],
+    coverage_opts = lcov_attrs["coverage_opts"],
+    instrumented_targets = lcov_attrs["instrumented_targets"],
     lcov_opts = [
         "--rc lcov_branch_coverage=1",
         "--list",
     ],
-    test_targets = ["//test/..."],
+    test_targets = lcov_attrs["test_targets"],
 )
 
 lcov(
     name = "lcov_html",
-    instrumented_targets = ["//:skytest"],
+    coverage_opts = lcov_attrs["coverage_opts"],
+    instrumented_targets = lcov_attrs["instrumented_targets"],
     lcov_opts = [
         "--show-details",
         "--keep-descriptions",
         "--branch-coverage",
         "--highlight",
+        "--demangle-cpp",
         "--missed",
         "--dark-mode",
     ],
     lcov_tool = "genhtml",
-    test_targets = ["//test/..."],
+    test_targets = lcov_attrs["test_targets"],
 )


### PR DESCRIPTION
Disable exceptions to reduce "hidden branches" analyzed by gcov. These
branches are not a realistic indicator of coverage as this library does
not explicitly allocate memory, throw exceptions, or catch exceptions.

Change-Id: I6df51846f4e3da70cc2d53b6e4e6e2b9be36a2f7