### PR TITLE
replace sigsegv in aborts test and enable sanitizers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,28 +7,6 @@ on:
     branches: [ "*" ]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [gcc, clang]
-        feature: ['', asan, tsan, ubsan]
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: ./.github/actions/ci-env-setup
-      with:
-        bazel-cache-key: bazel-test-${{ matrix.toolchain }}-${{ matrix.feature }}
-
-    - run: |
-        bazel \
-          test \
-          --config=${{ matrix.toolchain }} \
-          --features=${{ matrix.feature }} \
-          //...
-
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -48,43 +26,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./bazel-out/_coverage/_coverage_report.dat
         fail_ci_if_error: true
-
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        flag:
-          - '--config=clang-format'
-          - '--config=clang-tidy'
-          - '--config=verbose-clang-tidy'
-          - '--compilation_mode=opt'
-        exclude:
-          - flag: ${{ github.event_name == 'pull_request' && '--config=verbose-clang-tidy' || 'dummy' }}
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: ./.github/actions/ci-env-setup
-      with:
-        bazel-cache-key: bazel-build-${{ matrix.flag }}
-
-    - run: |
-        bazel \
-          build \
-          ${{ matrix.flag }} \
-          //...
-
-  buildifier:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: ./.github/actions/ci-env-setup
-      with:
-        bazel-cache-key: bazel-buildifier
-
-    - run: |
-        bazel \
-          run \
-          //tools:buildifier.check

--- a/rules/lcov.bzl
+++ b/rules/lcov.bzl
@@ -15,6 +15,12 @@ def lcov(
             "--test_output=errors",
             # https://github.com/bazelbuild/bazel/issues/13919
             "--test_env=COVERAGE_GCOV_OPTIONS=-b",
+            # https://bazel.build/configure/coverage#remote-execution
+            "--strategy=CoverageReport=local",
+            "--experimental_split_coverage_postprocessing",
+            "--experimental_fetch_all_coverage_outputs",
+            "--remote_download_outputs=all",
+            "--experimental_remote_download_regex='.*/((testlogs/.*/_coverage/.*)|coverage.dat$|_coverage/_coverage_report.dat$)'",
         ],
         lcov_tool = "lcov",
         lcov_opts = []):

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -240,16 +240,11 @@ skytest_test(
         "aborts.*PASS",
         "does not abort.*FAIL",
         "exited: 0",
-        "terminates due to sigsegv.*FAIL",
-        "signal: SIGSEGV",
+        "terminates due to sigint.*FAIL",
+        "signal: SIGINT",
         "exits without abort.*FAIL",
         "exited: 1",
         "1 test passed.*3 tests failed",
-    ],
-    deps = [
-        "//tools:incompatible_with_asan",
-        "//tools:incompatible_with_tsan",
-        "//tools:incompatible_with_ubsan_clang",
     ],
 )
 

--- a/test/aborts_test.cpp
+++ b/test/aborts_test.cpp
@@ -13,8 +13,8 @@ auto main() -> int
 
   "does not abort"_test = [] { return expect(aborts([] {})); };
 
-  "terminates due to sigsegv"_test = [] {
-    return expect(aborts([] { std::raise(SIGSEGV); }));
+  "terminates due to sigint"_test = [] {
+    return expect(aborts([] { std::raise(SIGINT); }));
   };
 
   "exits without abort"_test = [] {


### PR DESCRIPTION
Use sigint instead of sigsegv to allow use of asan, tsan, ubsan.

Change-Id: I8b033e14a97f22ff951652d6f5395d093a54c041