### PR TITLE
replace sigsegv in aborts test and enable sanitizers

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -240,16 +240,11 @@ skytest_test(
         "aborts.*PASS",
         "does not abort.*FAIL",
         "exited: 0",
-        "terminates due to sigsegv.*FAIL",
-        "signal: SIGSEGV",
+        "terminates due to sigint.*FAIL",
+        "signal: SIGINT",
         "exits without abort.*FAIL",
         "exited: 1",
         "1 test passed.*3 tests failed",
-    ],
-    deps = [
-        "//tools:incompatible_with_asan",
-        "//tools:incompatible_with_tsan",
-        "//tools:incompatible_with_ubsan_clang",
     ],
 )
 

--- a/test/aborts_test.cpp
+++ b/test/aborts_test.cpp
@@ -13,8 +13,8 @@ auto main() -> int
 
   "does not abort"_test = [] { return expect(aborts([] {})); };
 
-  "terminates due to sigsegv"_test = [] {
-    return expect(aborts([] { std::raise(SIGSEGV); }));
+  "terminates due to sigint"_test = [] {
+    return expect(aborts([] { std::raise(SIGINT); }));
   };
 
   "exits without abort"_test = [] {


### PR DESCRIPTION
Use sigint instead of sigsegv to allow use of asan, tsan, ubsan.

Change-Id: I2283dcbd59b767600cfe0f0bbb61828eccbfe0ac