### PR TITLE
exit normally in `aborts` predicate

### DIFF
--- a/.github/coverage.yml
+++ b/.github/coverage.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto 
+        flags: 
+          - unit
+        paths: 
+          - "src"
+       # advanced settings
+        branches: 
+          - master
+        if_ci_failed: error #success, failure, error, ignore
+        informational: false
+        only_pulls: false

--- a/src/runner.hpp
+++ b/src/runner.hpp
@@ -7,12 +7,20 @@
 #include <type_traits>
 
 namespace skytest {
+namespace detail {
+struct aborts_fn;
+}
 
 template <class Printer>
 class runner
 {
   mutable Printer printer_;
   mutable summary summary_{};
+  mutable bool silent_ = false;
+
+  friend struct ::skytest::detail::aborts_fn;
+
+  auto silence() const { silent_ = true; }
 
 public:
   template <
@@ -25,6 +33,10 @@ public:
 
   ~runner()
   {
+    if (silent_) {
+      return;
+    }
+
     printer_ << summary_;
 
     // NOLINTNEXTLINE(concurrency-mt-unsafe)


### PR DESCRIPTION
When testing that a closure calls `abort`, exit normally in the child
process if the test closure returns successfully. Previously, the child
process would call `_Exit` in order to terminate without flushing to
stdout. However, this also prevents gcov from writing coverage metrics
of the child process as this routine is registered with `atexit`.

This commit updates the abort predicate to send a flush command to the
printer before calling fork. The child process silences the printer
before invoking the test closure and exits normally if needed.

Change-Id: I0164e5752b4967ecad87c7fb7eee6622b847ab4b