### PR TITLE
use strsignal to display signal name

### DIFF
--- a/src/aborts.hpp
+++ b/src/aborts.hpp
@@ -6,6 +6,8 @@
 #include <cstring>
 #include <optional>
 #include <ostream>
+// https://www.man7.org/linux/man-pages/man3/strsignal.3.html
+#include <string.h>  // NOLINT(modernize-deprecated-headers)
 #include <sys/wait.h>
 #include <unistd.h>
 #include <utility>
@@ -33,8 +35,8 @@ struct aborts_fn
           os << "exited: " << WEXITSTATUS(*r.status);
         }
         if (WIFSIGNALED(*r.status)) {
-          os << "terminated due to signal: SIG"
-             << sigabbrev_np(WTERMSIG(*r.status));
+          // NOLINTNEXTLINE(concurrency-mt-unsafe)
+          os << "terminated due to signal: " << strsignal(WTERMSIG(*r.status));
         }
       }
       return os;

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -241,7 +241,7 @@ skytest_test(
         "does not abort.*FAIL",
         "exited: 0",
         "terminates due to sigint.*FAIL",
-        "signal: SIGINT",
+        "signal: Interrupt",
         "exits without abort.*FAIL",
         "exited: 1",
         "1 test passed.*3 tests failed",


### PR DESCRIPTION
Replace sigabbrev_np with strsignal. sibabbrev_np is not available
before glibc 2.32.

Change-Id: Ia031b760d8267d3dfd96a97fac28f373c57ac3cc